### PR TITLE
Make tslint's array-type option to be false

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,8 @@
         "interface-name": false,
         "no-console": false,
         "object-literal-sort-keys": false,
-        "no-var-requires": false
+        "no-var-requires": false,
+        "array-type": false
     },
     "jsRules": {
         "no-console": false,


### PR DESCRIPTION
After this commit we can use T[] type instead of Array<T>