### PR TITLE
Upgrade stringstream 0.0.5 to 0.0.6

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8705,13 +8705,10 @@ string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
-stringstream@~0.0.4:
+stringstream@~0.0.4, stringstream@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.6.tgz#7880225b0d4ad10e30927d167a1d6f2fd3b33a72"
-
-stringstream@~0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
+  integrity sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==
 
 strip-ansi@4.0.0, strip-ansi@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
stringstream below 0.0.6 has a vulnerability.
https://hackerone.com/reports/321670
Actually, it would not affect our project because it appears node 4.x and below, but we specified the project to use node 10.0 and above.
https://github.com/CodeChain-io/codechain-explorer/blob/d2f6dda828103b77c3170d47b6c49e7ff776248a/package.json#L12
But I think it's better to upgrade because we are using stringstream 0.0.5 and 0.0.6. I cannot find a reason to use two different versions of stringstream.